### PR TITLE
Add user profile page and DB resiliency

### DIFF
--- a/ChurchAttendanceApp/Pages/Account/Login.cshtml.cs
+++ b/ChurchAttendanceApp/Pages/Account/Login.cshtml.cs
@@ -45,8 +45,11 @@ public class LoginModel : PageModel
 
         if (!ModelState.IsValid) return Page();
 
+        var user = await _signInManager.UserManager.FindByEmailAsync(Input.Email);
+        if (user == null) return Page();
+
         var result = await _signInManager.PasswordSignInAsync(
-            Input.Email,
+            user.UserName!,
             Input.Password,
             Input.RememberMe,
             lockoutOnFailure: false); 

--- a/ChurchAttendanceApp/Pages/Account/Profile.cshtml
+++ b/ChurchAttendanceApp/Pages/Account/Profile.cshtml
@@ -1,0 +1,109 @@
+﻿@page
+@model ChurchAttendanceApp.Pages.Account.ProfileModel
+@{
+    ViewData["Title"] = Model.Input.UserName;
+}
+
+<div class="container py-4">
+    <div class="mb-4">
+        <a href="javascript:history.back()" class="outline-primary-btn btn px-3 py-2">
+            <i class="bi bi-arrow-left me-1"></i> Back
+        </a>
+    </div>
+
+    <div class="mx-auto max-w-600">
+
+        @if (Model.StatusMessage != null)
+        {
+            <div class="alert alert-success mb-4">@Model.StatusMessage</div>
+        }
+        <div class="card card-rounded mb-4 border-0 shadow-sm">
+            <div class="card-header-primary text-center py-4 px-4">
+                <h4 class="fw-bold mb-1">My Profile</h4>
+                <p class="header-subtext mb-0" style="font-size:0.9rem;">Manage your account information</p>
+            </div>
+            <div class="card-body p-4">
+                <form method="post" asp-page-handler="Profile">
+                    <div asp-validation-summary="ModelOnly" class="text-danger mb-3"></div>
+
+                    <div class="mb-3">
+                        <label asp-for="Input.UserName" class="form-label fw-semibold muted-text"></label>
+                        <input asp-for="Input.UserName" class="form-control input-border" />
+                        <span asp-validation-for="Input.UserName" class="text-danger small"></span>
+                    </div>
+
+                    <div class="mb-4">
+                        <label asp-for="Input.Email" class="form-label fw-semibold muted-text"></label>
+                        <input asp-for="Input.Email" class="form-control input-border" />
+                        <span asp-validation-for="Input.Email" class="text-danger small"></span>
+                    </div>
+
+                    <button type="submit" class="btn btn-fabac w-100 py-2 fw-semibold">
+                        <i class="bi bi-check-lg me-1"></i> Save Changes
+                    </button>
+                </form>
+            </div>
+        </div>
+
+        <div class="card card-rounded mb-4 border-0 shadow-sm">
+            <div class="card-header-primary text-center py-4 px-4">
+                <h4 class="fw-bold mb-1">Change Password</h4>
+                <p class="header-subtext mb-0" style="font-size:0.9rem;">Update your login credentials</p>
+            </div>
+            <div class="card-body p-4">
+                <form method="post" asp-page-handler="Password">
+                    <div asp-validation-summary="ModelOnly" class="text-danger mb-3"></div>
+
+                    <div class="mb-3">
+                        <label asp-for="PasswordChange.CurrentPassword" class="form-label fw-semibold muted-text"></label>
+                        <input asp-for="PasswordChange.CurrentPassword" class="form-control input-border" />
+                        <span asp-validation-for="PasswordChange.CurrentPassword" class="text-danger small"></span>
+                    </div>
+
+                    <div class="mb-3">
+                        <label asp-for="PasswordChange.NewPassword" class="form-label fw-semibold muted-text"></label>
+                        <input asp-for="PasswordChange.NewPassword" class="form-control input-border" />
+                        <span asp-validation-for="PasswordChange.NewPassword" class="text-danger small"></span>
+                    </div>
+
+                    <div class="mb-4">
+                        <label asp-for="PasswordChange.ConfirmNewPassword" class="form-label fw-semibold muted-text"></label>
+                        <input asp-for="PasswordChange.ConfirmNewPassword" class="form-control input-border" />
+                        <span asp-validation-for="PasswordChange.ConfirmNewPassword" class="text-danger small"></span>
+                    </div>
+
+                    <button type="submit" class="btn btn-warning w-100 py-2 fw-semibold">
+                        <i class="bi bi-lock me-1"></i> Change Password
+                    </button>
+                </form>
+            </div>
+        </div>
+
+    </div>
+
+    <div class="toast-container position-fixed bottom-0 end-0 p-3 w-auto" style="z-index: 9999">
+        @if (TempData["SuccessMessage"] != null)
+        {
+            <div id="successToast" class="toast align-items-center text-white bg-info border-0 w-auto"
+                 role="alert" data-bs-autohide="true" data-bs-delay="3000">
+                <div class="d-flex">
+                    <div class="toast-body fw-semibold d-flex flex-row gap-2 text-nowrap">
+                        <i class="bi bi-check-lg"></i> @TempData["SuccessMessage"]
+                    </div>
+                    <button type="button" class="btn-close btn-close-white me-2 m-auto flex-shrink-0" data-bs-dismiss="toast"></button>
+                </div>
+            </div>
+        }
+    </div>
+</div>
+
+@section Scripts {
+    <script>
+        document.addEventListener('DOMContentLoaded', function() {
+            const successToastEl = document.getElementById('successToast');
+            if (successToastEl) {
+                new bootstrap.Toast(successToastEl).show();
+            }
+        });
+    </script>
+}

--- a/ChurchAttendanceApp/Pages/Account/Profile.cshtml.cs
+++ b/ChurchAttendanceApp/Pages/Account/Profile.cshtml.cs
@@ -1,0 +1,139 @@
+using ChurchAttendanceApp.Models;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using System.ComponentModel.DataAnnotations;
+
+namespace ChurchAttendanceApp.Pages.Account;
+
+[Authorize]
+public class ProfileModel : PageModel
+{
+    private readonly UserManager<AppUser> _userManager;
+    private readonly SignInManager<AppUser> _signInManager;
+
+    public ProfileModel(UserManager<AppUser> userManager, SignInManager<AppUser> signInManager)
+    {
+        _userManager = userManager;
+        _signInManager = signInManager;
+    }
+
+    [TempData]
+    public string? StatusMessage { get; set; }
+
+    [BindProperty]
+    public ProfileInput Input { get; set; } = new();
+
+    [BindProperty]
+    public PasswordInput PasswordChange { get; set; } = new();
+
+    public class ProfileInput
+    {
+        [Required]
+        [Display(Name = "Username")]
+        public string UserName { get; set; } = string.Empty;
+
+        [Required]
+        [EmailAddress]
+        public string Email { get; set; } = string.Empty;
+    }
+
+    public class PasswordInput
+    {
+        [DataType(DataType.Password)]
+        [Display(Name = "Current Password")]
+        public string? CurrentPassword { get; set; }
+
+        [MinLength(8)]
+        [DataType(DataType.Password)]
+        [Display(Name = "New Password")]
+        public string? NewPassword { get; set; }
+
+        [DataType(DataType.Password)]
+        [Compare("NewPassword", ErrorMessage = "Passwords do not match.")]
+        [Display(Name = "Confirm New Password")]
+        public string? ConfirmNewPassword { get; set; }
+    }
+
+    public async Task<IActionResult> OnGetAsync()
+    {
+        var user = await _userManager.GetUserAsync(User);
+        if (user == null) return NotFound();
+
+        Input = new ProfileInput
+        {
+            UserName = user.UserName!,
+            Email = user.Email!
+        };
+
+        return Page();
+    }
+
+    public async Task<IActionResult> OnPostProfileAsync()
+    {
+        if (!ModelState.IsValid) return Page();
+
+        var user = await _userManager.GetUserAsync(User);
+        if (user == null) return NotFound();
+
+        // update username
+        if (user.UserName != Input.UserName)
+        {
+            var setUserName = await _userManager.SetUserNameAsync(user, Input.UserName);
+            if (!setUserName.Succeeded)
+            {
+                foreach (var error in setUserName.Errors)
+                    ModelState.AddModelError(string.Empty, error.Description);
+                return Page();
+            }
+        }
+
+        // update email
+        if (user.Email != Input.Email)
+        {
+            var setEmail = await _userManager.SetEmailAsync(user, Input.Email);
+            if (!setEmail.Succeeded)
+            {
+                foreach (var error in setEmail.Errors)
+                    ModelState.AddModelError(string.Empty, error.Description);
+                return Page();
+            }
+        }
+
+        await _signInManager.RefreshSignInAsync(user); // refresh cookie
+        StatusMessage = "Profile updated successfully.";
+        TempData["SuccessMessage"] = $"{user.UserName}'s profile has been updated successfully.";
+        return RedirectToPage();
+    }
+
+    public async Task<IActionResult> OnPostPasswordAsync()
+    {
+        var user = await _userManager.GetUserAsync(User);
+        if (user == null) return NotFound();
+
+        if (string.IsNullOrEmpty(PasswordChange.CurrentPassword) ||
+            string.IsNullOrEmpty(PasswordChange.NewPassword))
+        {
+            ModelState.AddModelError(string.Empty, "Please fill in all password fields.");
+            return Page();
+        }
+
+        var result = await _userManager.ChangePasswordAsync(
+            user,
+            PasswordChange.CurrentPassword,
+            PasswordChange.NewPassword);
+
+        if (!result.Succeeded)
+        {
+            foreach (var error in result.Errors)
+                ModelState.AddModelError(string.Empty, error.Description);
+            return Page();
+        }
+
+        await _signInManager.RefreshSignInAsync(user);
+        StatusMessage = "Password changed successfully.";
+        TempData["SuccessMessage"] = $"{user.UserName}'s Password has been updated successfully.";
+        return RedirectToPage();
+    }
+}

--- a/ChurchAttendanceApp/Pages/Shared/_Layout.cshtml
+++ b/ChurchAttendanceApp/Pages/Shared/_Layout.cshtml
@@ -72,6 +72,12 @@
                                     <i class="bi bi-calendar-check-fill me-2 d-lg-none"></i>Attendance
                                 </a>
                             </li>
+                            <li class="nav-item">
+                                <a class="nav-link px-3 py-2 fw-medium fabac-nav-link text-center @(currentPage == "/Account/Profile" ? "fabac-nav-link--active" : "")"
+                                       asp-page="/Account/Profile">
+                                    <i class="bi bi-calendar-check-fill me-2 d-lg-none"></i>Profile
+                                </a>
+                            </li>
                         }
 
                         <!-- Desktop divider only -->
@@ -87,7 +93,7 @@
                         <!-- User chip -->
                         <li class="nav-item d-flex align-items-center gap-2 px-3 py-1 user-chip justify-content-center">
                             <i class="bi bi-person-circle"></i>
-                            <span class="fw-medium small user-chip-text">Admin</span>
+                            <span class="fw-medium small user-chip-text">@User.Identity!.Name</span>
                         </li>
 
                         <!-- Log Out -->

--- a/ChurchAttendanceApp/Program.cs
+++ b/ChurchAttendanceApp/Program.cs
@@ -11,7 +11,16 @@ using Scalar.AspNetCore;
 var builder = WebApplication.CreateBuilder(args);
 
 builder.Services.AddDbContext<ChurchDbContext>(options =>
-    options.UseNpgsql(builder.Configuration.GetConnectionString("DefaultConnection")));
+    options.UseNpgsql(builder.Configuration.GetConnectionString("DefaultConnection"),
+        npgsqlOptions =>
+        {
+            npgsqlOptions.EnableRetryOnFailure(
+                maxRetryCount: 5,
+                maxRetryDelay: TimeSpan.FromSeconds(10),
+                errorCodesToAdd: null);
+            npgsqlOptions.CommandTimeout(60);
+        }
+    ));
 
 builder.Services.AddIdentity<AppUser, IdentityRole>(options =>
 {
@@ -64,6 +73,25 @@ builder.Services.AddScoped<ExportService>();
 builder.Services.AddRazorPages();
 
 var app = builder.Build();
+
+using (var scope = app.Services.CreateScope())
+{
+    var db = scope.ServiceProvider.GetRequiredService<ChurchDbContext>();
+    var retries = 0;
+    while (retries < 5)
+    {
+        try
+        {
+            await db.Database.CanConnectAsync();
+            break;
+        }
+        catch
+        {
+            retries++;
+            await Task.Delay(TimeSpan.FromSeconds(3));
+        }
+    }
+}
 
 if (app.Environment.IsDevelopment())
 {


### PR DESCRIPTION
Add a new Profile Razor page and PageModel to let authenticated users view/update username/email and change passwords (Profile.cshtml / Profile.cshtml.cs). Update Login handler to resolve users by email and sign in with their username. Add a Profile link and dynamic username display to the shared layout. Configure Npgsql with retry-on-failure and a 60s command timeout, and add a startup loop to wait for DB connectivity.